### PR TITLE
use pdm pep517 to build

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,6 @@
 [build-system]
-requires = ["setuptools", "wheel"]
+requires = ["pdm-pep517"]
+build-backend = "pdm.pep517.api"
 
 [tool.pdm]
 name = "python-cfonts"


### PR DESCRIPTION
Use pdm-pep517 to build instead of setuptools since building from source is not working with setuptools.

Fixes #36 