### PR TITLE
ci: update pdm config command, add python 3.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [2.7, 3.5, 3.6, 3.7, 3.8]
+        python-version: [2.7, 3.5, 3.6, 3.7, 3.8, 3.9]
         os: [ubuntu-latest, macOS-latest, windows-latest]
 
     steps:
@@ -43,7 +43,7 @@ jobs:
       - name: Install dependencies
         run: |
           pdm use -f ${{ matrix.python-version }}
-          pdm config set parallel_install false
+          pdm config parallel_install false
           pip install wheel
           pdm install -d
       - name: Run Tests


### PR DESCRIPTION
Addresses https://github.com/frostming/python-cfonts/pull/37/checks?check_run_id=1354075640#step:6:13 from CI and adds Python 3.9
```
Run pdm use -f 2.7
  pdm use -f 2.7
  pdm config set parallel_install false
  pip install wheel
  pdm install -d
  shell: /bin/bash -e {0}
  env:
    pythonLocation: /opt/hostedtoolcache/Python/2.7.18/x64
Using Python interpreter: /opt/hostedtoolcache/Python/2.7.18/x64/bin/python2.7 (2.7.18)
usage: pdm [-h] [-V] [-v]
           {add,build,cache,completion,config,export,import,info,init,install,list,lock,remove,run,search,show,sync,update,use}
           ...
pdm: error: unrecognized arguments: false
Error: Process completed with exit code 2.
```