### PR TITLE
Add copyable mode

### DIFF
--- a/cfonts/cli.py
+++ b/cfonts/cli.py
@@ -127,6 +127,13 @@ def parse_args() -> argparse.Namespace:
         help="Set this option to generate your own gradients. Each color set "
         "in the gradient option will then be transitioned to directly.",
     )
+    parser.add_argument(
+        "-u",
+        "--copyable",
+        action="store_true",
+        help="Instead of printing the colors, print the ANSI escape codes, so it "
+        "can be copied and pasted into a Python print statement.",
+    )
     parser.add_argument("text")
     if len(sys.argv) == 1:
         parser.print_help()
@@ -155,6 +162,7 @@ def main() -> None:
         "gradient": gradient,
         "independent_gradient": args.independent_gradient,
         "transition": args.transition,
+        "copyable": args.copyable,
     }
     if args.letter_spacing is not None:
         options["letter_spacing"] = args.letter_spacing

--- a/cfonts/cli.py
+++ b/cfonts/cli.py
@@ -128,8 +128,8 @@ def parse_args() -> argparse.Namespace:
         "in the gradient option will then be transitioned to directly.",
     )
     parser.add_argument(
-        "-u",
-        "--copyable",
+        "-r",
+        "--raw",
         action="store_true",
         help="Instead of printing the colors, print the ANSI escape codes, so it "
         "can be copied and pasted into a Python print statement.",
@@ -162,7 +162,7 @@ def main() -> None:
         "gradient": gradient,
         "independent_gradient": args.independent_gradient,
         "transition": args.transition,
-        "copyable": args.copyable,
+        "raw": args.raw,
     }
     if args.letter_spacing is not None:
         options["letter_spacing"] = args.letter_spacing

--- a/cfonts/core.py
+++ b/cfonts/core.py
@@ -361,7 +361,7 @@ def render(
         # replace the escape character with the bytes for the escape character
         # \033 also works
         output = output.replace("\x1b", "\\x1b")
-    
+
     return output
 
 

--- a/cfonts/core.py
+++ b/cfonts/core.py
@@ -247,6 +247,7 @@ def render(
     gradient: Optional[List[str]] = None,
     independent_gradient: bool = False,
     transition: bool = False,
+    copyable: bool = False,
 ) -> str:
     """Main function to get the colored output for a string.
 

--- a/cfonts/core.py
+++ b/cfonts/core.py
@@ -247,7 +247,7 @@ def render(
     gradient: Optional[List[str]] = None,
     independent_gradient: bool = False,
     transition: bool = False,
-    copyable: bool = False,
+    raw: bool = False,
 ) -> str:
     """Main function to get the colored output for a string.
 
@@ -355,14 +355,12 @@ def render(
         if output:
             output[0] = style.open + output[0]
             output[-1] += style.close
-    # easier to be before copyable, so you don't have to loop
-    output = "\n".join(output)
-    if copyable:
+    if raw:
         # replace the escape character with the bytes for the escape character
         # \033 also works
-        output = output.replace("\x1b", "\\x1b")
-
-    return output
+        return "\n".join(output).replace("\x1b", "\\x1b")
+    else:
+        return "\n".join(output)
 
 
 def say(text: str, **options) -> None:

--- a/cfonts/core.py
+++ b/cfonts/core.py
@@ -358,7 +358,7 @@ def render(
     if raw:
         # replace the escape character with the bytes for the escape character
         # \033 also works
-        return "\n".join(output).replace("\x1b", "\\x1b")
+        return repr("\n".join(output))[1:-1]
     else:
         return "\n".join(output)
 

--- a/cfonts/core.py
+++ b/cfonts/core.py
@@ -354,7 +354,14 @@ def render(
         if output:
             output[0] = style.open + output[0]
             output[-1] += style.close
-    return "\n".join(output)
+    # easier to be before copyable, so you don't have to loop
+    output = "\n".join(output)
+    if copyable:
+        # replace the escape character with the bytes for the escape character
+        # \033 also works
+        output = output.replace("\x1b", "\\x1b")
+    
+    return output
 
 
 def say(text: str, **options) -> None:


### PR DESCRIPTION
Adds a copyable mode, so it could actually be used in a CLI. I sort of wanted to use this in a CLI, copyable mode just prints out the actual ANSI escape codes so they can be copied and pasted. `-c` was already taken in the argument parser, so I had to use `-u`.